### PR TITLE
Add ability to change Qt logging categories

### DIFF
--- a/daemon/sailfish-secretsd.service
+++ b/daemon/sailfish-secretsd.service
@@ -7,6 +7,7 @@ Conflicts=shutdown.target jolla-actdead-charging.service
 [Service]
 Type=dbus
 BusName=org.sailfishos.secrets.daemon.discovery
+EnvironmentFile=-/var/lib/environment/sailfish-secretsd/*.conf
 ExecStart=/usr/bin/invoker -o --type=qt5 /usr/bin/sailfishsecretsd
 Restart=always
 


### PR DESCRIPTION
This commit adds "EnvironmentFile" option for the sailfish-secretsd unit file.
After these changes the service will be able to change logging categories at
runtime. The easiest way to do this is to install a special rpm logging package
which installs a file into this directory.